### PR TITLE
Add portfolio allocation visualization

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ pip install -r requirements.txt
 3. **Exibição dos Resultados**:
    - O melhor portfólio de cada geração será exibido com os **pesos** das ações e o **índice de Sharpe**.
    - O gráfico da evolução do índice de Sharpe ao longo das gerações será mostrado no final.
+   - Ao final, também é apresentado um **gráfico de barras** com a distribuição dos pesos do melhor portfólio, facilitando a visualização da alocação de cada ação.
 
 ### Estrutura do Código
 

--- a/Tech_Challenge_Fase02.ipynb
+++ b/Tech_Challenge_Fase02.ipynb
@@ -826,6 +826,35 @@
   },
   {
    "cell_type": "markdown",
+   "metadata": {},
+   "id": "visual_weights_md",
+   "source": [
+    "## Visualização Gráfica da Alocação do Melhor Portfólio\n",
+    "\n",
+    "O gráfico abaixo mostra a distribuição dos pesos de cada ação no melhor portfólio encontrado.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "id": "visual_weights_code",
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "import matplotlib.pyplot as plt\n",
+    "\n",
+    "plt.figure(figsize=(8, 4))\n",
+    "plt.bar(tickers, best_portfolio, color='skyblue')\n",
+    "plt.xlabel('Ações')\n",
+    "plt.ylabel('Peso')\n",
+    "plt.title('Distribuição de Pesos no Melhor Portfólio')\n",
+    "plt.ylim(0, 1)\n",
+    "plt.grid(axis='y', linestyle='--', alpha=0.7)\n",
+    "plt.show()\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "6cbfe364",
    "metadata": {},
    "source": [


### PR DESCRIPTION
## Summary
- add a bar chart cell to visualize weights of the optimized portfolio
- mention the new chart in the README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6881899bdefc8321841f3567c64075ec